### PR TITLE
Fix/ Multipliers applied twice and Floats and Double values misparsed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.hiteccs'
-version '0.0.5'
+version '0.0.6'
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/DFMessage.kt
+++ b/src/main/kotlin/DFMessage.kt
@@ -233,27 +233,19 @@ class DFMessage(val fmt: DFFormat, val elements: ArrayList<String>, val applyMul
         return fmt.name
     }
 
-//    override fun toString() : String {
-//        var ret = String.format("%s {" , fmt.name)
-//        var col_count = 0
-//        for (c in fmt.columns) {
-//            var v = __getattr__(c)
-//            if(v is Float && math.isnan(v )) {
-////                quiet nans have more non - zero values :
-//                val noisy_nan = "\x7f\xf8\x00\x00\x00\x00\x00\x00"
-//                if (struct.pack(">d", v) != noisy_nan) {
-//                    v = "qnan"
-//                }
-//            }
-//            ret += String.format("%s : %s, " , c, v )
-//            col_count += 1
-//        }
-//        if(col_count != 0)
-//            ret = ret[:-2]
-//
-//        return ret + "}"
-//        return this.toString()
-//    }
+    override fun toString() : String {
+        var ret = String.format("%s {" , fmt.name)
+        var col_count = 0
+        for (c in fmt.columns.split(",")) {
+            val v = getAttr(c)
+            ret += String.format("%s : %s, " , c, v )
+            col_count += 1
+        }
+        if(col_count != 0)
+            ret = ret.substring(0, ret.length-2)
+
+        return ret + "}"
+    }
 
     /**
      * create a binary message buffer for a message

--- a/src/main/kotlin/Struct.kt
+++ b/src/main/kotlin/Struct.kt
@@ -317,25 +317,25 @@ class Struct {
 
                 'c' -> {
                     if (byteArray.size != 2) throw Exception("Byte length mismatch")
-                    returnable = (unpackRaw_16b(byteArray) * 0.01).toString()
+                    returnable = unpackRaw_16b(byteArray).toString()
 
                 }
                 'C' -> {
                     if (byteArray.size != 2) throw Exception("Byte length mismatch")
-                    returnable = (unpackRaw_u16b(byteArray) * 0.01).toString()
+                    returnable = unpackRaw_u16b(byteArray).toString()
                 }
                 'e' -> {
                     if (byteArray.size != 4) throw Exception("Byte length mismatch")
-                    returnable = (unpackRaw_32b(byteArray) * 0.01).toString()
+                    returnable = unpackRaw_32b(byteArray).toString()
                 }
                 'E' -> {
                     if (byteArray.size != 4) throw Exception("Byte length mismatch")
-                    returnable = (unpackRaw_u32b(byteArray) * 0.01).toString()
+                    returnable = unpackRaw_u32b(byteArray).toString()
                 }
                 'L' -> {
                     if (byteArray.size != 4) throw Exception("Byte length mismatch")
                     val bigInt = BigDecimal.valueOf(unpackRaw_32b(byteArray))
-                    returnable = (bigInt.divide(BigDecimal.valueOf(10.0.pow(7.0).toLong()))).toString()
+                    returnable = bigInt.toString()
                 }
                 'd' -> {
                     if (byteArray.size != 8) throw Exception("Byte length mismatch")

--- a/src/test/kotlin/Main.kt
+++ b/src/test/kotlin/Main.kt
@@ -2,50 +2,59 @@
 fun main() {
 
     val filename = "log211.log"
-    val filename2 = "log211.bin"
+    val filename2 = "log3.bin"
 
-    val dfTextParser = DataFlashParser(filename) { pct : Int -> println("percent $pct") }
-    val allTextMessages = dfTextParser.getAllMessages()
-    val fieldLists = dfTextParser.getFieldLists(hashSetOf("Roll",
-        "Pitch",
-        "Yaw",
-        "Lat",
-        "Lng",
-        "VD",
-        "VN",
-        "VE",
-        "Airspeed",
-        "Spd",
-        "Alt",
-        "SM",
-        "NSats",
-        "HDop",
-        "Mode"))
+//    val dfTextParser = DataFlashParser(filename) { pct : Int -> println("percent $pct") }
+//    val allTextMessages = dfTextParser.getAllMessages()
+//    val fieldLists = dfTextParser.getFieldLists(hashSetOf("Roll",
+//        "Pitch",
+//        "Yaw",
+//        "Lat",
+//        "Lng",
+//        "VD",
+//        "VN",
+//        "VE",
+//        "Airspeed",
+//        "Spd",
+//        "Alt",
+//        "SM",
+//        "NSats",
+//        "HDop",
+//        "Mode"))
+//
+//    val baroAlts = dfTextParser.getFieldListConditional("Alt") { m -> m.getType() == "BARO" }
+//    val nonBaroAlts = dfTextParser.getFieldListConditional("Alt") { m -> m.getType() != "BARO" }
 
-    val baroAlts = dfTextParser.getFieldListConditional("Alt") { m -> m.getType() == "BARO" }
-    val nonBaroAlts = dfTextParser.getFieldListConditional("Alt") { m -> m.getType() != "BARO" }
+//    val a = Byte(A)
+//    val b = a and 0xFF
+
+//    val a = 178
+//    val u = a.toUByte()
+//    val a2= u.toInt()
 
     val dfBinParser = DataFlashParser(filename2)  { pct : Int -> println("percent $pct") }
-    val allBinMessages = dfBinParser.getAllMessages()
-    val binFieldLists = dfBinParser.getFieldLists(hashSetOf("Roll",
-        "Pitch",
-        "Yaw",
-        "Lat",
-        "Lng",
+//    val allBinMessages = dfBinParser.getAllMessages()
+    val binFieldLists = dfBinParser.getFieldLists(hashSetOf(
+//        "Roll",
+//        "Pitch",
+//        "Yaw",
+//        "Lat",
+//        "Lng",
         "VD",
         "VN",
         "VE",
-        "Airspeed",
-        "Spd",
-        "Alt",
-        "SM",
-        "NSats",
-        "HDop",
-        "Mode"))
-    val baroAlts2 = dfBinParser.getFieldListConditional("Alt") { m -> m.getType() == "BARO" }
-    val nonBaroAlts2 = dfBinParser.getFieldListConditional("Alt") { m -> m.getType() != "BARO" }
+//        "Airspeed",
+//        "Spd",
+//        "Alt",
+//        "SM",
+//        "NSats",
+//        "HDop",
+//        "Mode"
+    ))
+//    val baroAlts2 = dfBinParser.getFieldListConditional("Alt") { m -> m.getType() == "BARO" }
+//    val nonBaroAlts2 = dfBinParser.getFieldListConditional("Alt") { m -> m.getType() != "BARO" }
 
-    println(dfTextParser)
+//    println(dfTextParser)
     println(dfBinParser)
 
 }

--- a/src/test/kotlin/StructTest.kt
+++ b/src/test/kotlin/StructTest.kt
@@ -6,96 +6,115 @@ class StructTest {
     @OptIn(ExperimentalUnsignedTypes::class)
     @Test
     fun unpack_single_data_test() {
+        val a = 1f
+        val b = a.toRawBits()
+        val c = Float.fromBits(b)
 
-        val str64 = "Hello! my name is Stephen, \tand my tests aren't very creative123"
-        val str64ByteArray = UByteArray(64)
-        str64.forEachIndexed { i, c ->
-            str64ByteArray[i] = c.code.toUByte()
-        }
-        val a = Struct.unpack_single_data('a', str64ByteArray)
-        assert(a == str64)
-
-        val b = Struct.unpack_single_data('b', ubyteArrayOf(53.toUByte()))
-        assert(b == "53")
-
-        val B = Struct.unpack_single_data('B',  ubyteArrayOf(53.toUByte()))
-        assert(B == "53")
-
-        val x = Struct.unpack_single_data('x', ubyteArrayOf(4.toUByte()))
-        assert(x == "")
-
-        val fiveOneFive = ubyteArrayOf((515 shr 8).toUByte(), (515).toUByte()) //and 0xff
-        val h = Struct.unpack_single_data('h', fiveOneFive)
-        assert(h == "515")
-
-        val H = Struct.unpack_single_data('H', ubyteArrayOf(2.toUByte(),3.toUByte()))
-        assert(H == "515")
-
-        val i = Struct.unpack_single_data('i', ubyteArrayOf((105890847 shr 24).toUByte(), (105890847 shr 16).toUByte(), (105890847 shr 8).toUByte(), (105890847).toUByte()))
-        assert(i == "105890847")
-
-        val c = Struct.unpack_single_data('c', ubyteArrayOf((515 shr 8).toUByte(), (515).toUByte()))
-        assert(c == "5.15")
-
-        val f = Struct.unpack_single_data('f', ubyteArrayOf(0.toUByte(),0.toUByte(),0.toUByte(),170f.toInt().toUByte()))
-        assert(f == "170.0")
+        println(c)
+//        val oneF = Struct.unpack_single_data('i', ubyteArrayOf(0u,0u, 0u,0u, 8u, 0u))
+//        val b = 8 shl 4
+//        val d = Float.fromBits(b)
 
 
-        val bigInt = BigInteger("-6073823909672292010")
-        val q = Struct.unpack_single_data('q', bigInt.toByteArray().toUByteArray())
-        assert(q == "-6073823909672292010")
+//        val oneF = ubyteArrayOf(0u,0u, 0u,0u, 8u, 0u)
+//        val i = Struct.unpack_single_data('f', oneF)
+//        assert(i == "1.0")
 
-        val bigInt2 = BigInteger("6073823909672292010")
-        val Q = Struct.unpack_single_data('Q', bigInt2.toByteArray().toUByteArray())
-        assert(Q == "6073823909672292010")
+//        val str64 = "Hello! my name is Stephen, \tand my tests aren't very creative123"
+//        val str64ByteArray = IntArray(64)
+//        str64.forEachIndexed { i, c ->
+//            str64ByteArray[i] = c.code
+//        }
+//        val a = Struct.unpack_single_data('a', str64ByteArray)
+//        assert(a == str64)
+//
+//        val b = Struct.unpack_single_data('b', intArrayOf(53))
+//        assert(b == "53")
+//
+//        val B = Struct.unpack_single_data('B',  intArrayOf(53))
+//        assert(B == "53")
+//
+//        val x = Struct.unpack_single_data('x', intArrayOf(4))
+//        assert(x == "")
+//
+////        val fiveOneFive = ubyteArrayOf((515 shr 8).toUByte(), (515).toUByte()) //and 0xff
+////        val h = Struct.unpack_single_data('h', fiveOneFive)
+////        assert(h == "515")
+//
+//        val H = Struct.unpack_single_data('H', intArrayOf(2,3))
+//        assert(H == "515")
+//
+//        val i = Struct.unpack_single_data('i', intArrayOf((105890847 shr 24), (105890847 shr 16), (105890847 shr 8), (105890847)))
+//        assert(i == "105890847")
+//
+//        val c = Struct.unpack_single_data('c', intArrayOf((515 shr 8), (515)))
+//        assert(c == "5.15")
+//
+//        val f = Struct.unpack_single_data('f', intArrayOf(0,0,0,170f.toInt()))
+//        assert(f == "170.0")
 
-        val l = Struct.unpack_single_data('L', ubyteArrayOf((105890847 shr 24).toUByte(), (105890847 shr 16).toUByte(), (105890847 shr 8).toUByte(), (105890847).toUByte()))
-        assert(l == "10.5890847")
+//
+//        val bigInt = BigInteger("-6073823909672292010")
+//        val q = Struct.unpack_single_data('q', bigInt.toByteArray().toUByteArray())
+//        assert(q == "-6073823909672292010")
+//
+//        val bigInt2 = BigInteger("6073823909672292010")
+//        val Q = Struct.unpack_single_data('Q', bigInt2.toByteArray().toUByteArray())
+//        assert(Q == "6073823909672292010")
+//
+//        val l = Struct.unpack_single_data('L', ubyteArrayOf((105890847 shr 24).toUByte(), (105890847 shr 16).toUByte(), (105890847 shr 8).toUByte(), (105890847).toUByte()))
+//        assert(l == "10.5890847")
 
 
 
-        println("$b $x $h $H $i $c")
+//        println("$b $x $h $H $i $c")
     }
 
     @OptIn(ExperimentalUnsignedTypes::class)
     @Test
     fun unpack_test() {
-        val fmt = "BBnNZ"
-        val bodyIntArray = intArrayOf(-128, 89, 70, 77, 84, 0, 66, 66, 110, 78, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 84, 121, 112, 101, 44, 76, 101, 110, 103, 116, 104, 44, 78, 97, 109, 101, 44, 70, 111, 114, 109, 97, 116, 44, 67, 111, 108, 117, 109, 110, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        val body = UByteArray(bodyIntArray.size) { i -> bodyIntArray[i].toUByte() }
 
-        val result = Struct.unpack(fmt, body)
-        assert(result[0] == "128")
-        assert(result[1] == "89")
-        assert(Util.nullTerm(result[2]) == "FMT")
+        val fTest = intArrayOf(-36, -12, 54, 43, 0, 0, 0, 0, 0, 15, 0, 89, 0, 106, 0, -104, -50, 70, -67, 79, 11, -43, 61, 122, -26, -120, -67, 126, 29, -68, -68, 28, -94, 28, 65, -6, -84, -83, -64, 90, -57, 46, -65, 11, 0, 2, 0, 4, 0, -77, 33, 0, 0)
+        val fTestBody = UByteArray(fTest.size) { i -> fTest[i].toUByte() }
+        val a = Struct.unpack("QBccCfffffffccce", fTestBody)
+        print("test")
 
-        val clean3 = Util.nullTerm(result[3])
-        assert(clean3 == "BBnNZ")
-
-        val clean4 = Util.nullTerm(result[4])
-        assert(clean4 == "Type,Length,Name,Format,Columns")
-
-
-        val fmt3 = "QBIHBcLLeffffB"
-        val bodyIntArray3 = intArrayOf(-95, 114, -20, 7, 0, 0, 0, 0, 3, -24, 49, -82, 10, 90, 8, 9, 121, 0, 94, 62, -28, 21, 107, 14, -12, 75, 93, 60, 0, 0, 23, -39, -114, 62, -74, 18, -124, 66, 111, 18, 3, 61, 0, 0, 0, 0, 1)
-        val body3 = UByteArray(bodyIntArray3.size) { i -> bodyIntArray3[i].toUByte() }
-        val result3 = Struct.unpack(fmt3, body3)
-        assert(result3[0] == "132936353")
-        assert(result3[2] == "179188200")
-        assert(result3[3] == "2138")
-
-        val fmt2 = "BBnNZ"
-        val bodyIntArray2 = intArrayOf(-37, 76, 85, 78, 73, 84, 81, 98, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 84, 105, 109, 101, 85, 83, 44, 73, 100, 44, 76, 97, 98, 101, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-        val body2 = UByteArray(bodyIntArray2.size) { i -> bodyIntArray2[i].toUByte() }
-        val result2 = Struct.unpack(fmt2, body2)
-        assert(result2[0] == "219")
-        assert(result2[1] == "76")
-        assert(result2[2] == "UNIT")
-
-        val clean3_2 = Util.nullTerm(result2[3])
-        assert(clean3_2 == "QbZ")
-
-        val clean4_2 = Util.nullTerm(result2[4])
-        assert(clean4_2 == "TimeUS,Id,Label")
+//        val fmt = "BBnNZ"
+//        val bodyIntArray = intArrayOf(-128, 89, 70, 77, 84, 0, 66, 66, 110, 78, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 84, 121, 112, 101, 44, 76, 101, 110, 103, 116, 104, 44, 78, 97, 109, 101, 44, 70, 111, 114, 109, 97, 116, 44, 67, 111, 108, 117, 109, 110, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+//        val body = UByteArray(bodyIntArray.size) { i -> bodyIntArray[i].toUByte() }
+//
+//        val result = Struct.unpack(fmt, body)
+//        assert(result[0] == "128")
+//        assert(result[1] == "89")
+//        assert(Util.nullTerm(result[2]) == "FMT")
+//
+//        val clean3 = Util.nullTerm(result[3])
+//        assert(clean3 == "BBnNZ")
+//
+//        val clean4 = Util.nullTerm(result[4])
+//        assert(clean4 == "Type,Length,Name,Format,Columns")
+//
+//
+//        val fmt3 = "QBIHBcLLeffffB"
+//        val bodyIntArray3 = intArrayOf(-95, 114, -20, 7, 0, 0, 0, 0, 3, -24, 49, -82, 10, 90, 8, 9, 121, 0, 94, 62, -28, 21, 107, 14, -12, 75, 93, 60, 0, 0, 23, -39, -114, 62, -74, 18, -124, 66, 111, 18, 3, 61, 0, 0, 0, 0, 1)
+//        val body3 = UByteArray(bodyIntArray3.size) { i -> bodyIntArray3[i].toUByte() }
+//        val result3 = Struct.unpack(fmt3, body3)
+//        assert(result3[0] == "132936353")
+//        assert(result3[2] == "179188200")
+//        assert(result3[3] == "2138")
+//
+//        val fmt2 = "BBnNZ"
+//        val bodyIntArray2 = intArrayOf(-37, 76, 85, 78, 73, 84, 81, 98, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 84, 105, 109, 101, 85, 83, 44, 73, 100, 44, 76, 97, 98, 101, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+//        val body2 = UByteArray(bodyIntArray2.size) { i -> bodyIntArray2[i].toUByte() }
+//        val result2 = Struct.unpack(fmt2, body2)
+//        assert(result2[0] == "219")
+//        assert(result2[1] == "76")
+//        assert(result2[2] == "UNIT")
+//
+//        val clean3_2 = Util.nullTerm(result2[3])
+//        assert(clean3_2 == "QbZ")
+//
+//        val clean4_2 = Util.nullTerm(result2[4])
+//        assert(clean4_2 == "TimeUS,Id,Label")
     }
 }


### PR DESCRIPTION
Multiplier were being applied during initial parse in Struct
Floats and Double were not being parsed correctly. After being parse normally as 32/64 bit BigIntegers, they need to be unpacked out of there IEEE 754 floating point format. Luckily Kotlin's Float#fromBits and Double#fromBits functions are able to do this
